### PR TITLE
fix generator and add comment on top of the file

### DIFF
--- a/lib/generators/pg_cron_job/templates/pg_cron_job_migration.erb
+++ b/lib/generators/pg_cron_job/templates/pg_cron_job_migration.erb
@@ -1,4 +1,4 @@
-<%# frozen_string_literal: true %>
+# frozen_string_literal: true
 
 class <%= migration_class_name %> < ActiveRecord::Migration<%= migration_version %>
   def up

--- a/lib/generators/pg_cron_job/templates/pg_cron_job_migration.erb
+++ b/lib/generators/pg_cron_job/templates/pg_cron_job_migration.erb
@@ -1,9 +1,11 @@
+<%# frozen_string_literal: true %>
+
 class <%= migration_class_name %> < ActiveRecord::Migration<%= migration_version %>
   def up
     schedule_pg_cron_job "<%= file_name %>"
   end
 
-  down
+  def down
     unschedule_pg_cron_job "<%= file_name %>"
   end
 end


### PR DESCRIPTION
There is a typo when generating the template for`pg_cron_job_migration.erb`
It fixes it and also adds the comment on top of the file.